### PR TITLE
Enforce valence constraints

### DIFF
--- a/fitting.py
+++ b/fitting.py
@@ -321,14 +321,10 @@ def connect_the_dots(mol, atoms, struct, maxbond=4):
     
     Assumes no hydrogens or existing bonds.
     '''
-<<<<<<< HEAD
     pt = Chem.GetPeriodicTable()
     
-    mol.BeginModify()
-=======
     if len(atoms) == 0:
         return
->>>>>>> upstream/master
 
     mol.BeginModify()
 
@@ -341,7 +337,7 @@ def connect_the_dots(mol, atoms, struct, maxbond=4):
         for (j,b) in enumerate(atoms):
             if a == b:
                 break
-            if dists[i,j] < 0.4:
+            if dists[i,j] < 0.01:  #reduce from 0.4
                 continue #don't bond too close atoms
             if dists[i,j] < maxbond:
                 flag = 0
@@ -351,41 +347,69 @@ def connect_the_dots(mol, atoms, struct, maxbond=4):
                 
     atom_maxb = {}
     for (i,a) in enumerate(atoms):
-        maxb = pt.GetDefaultValence(a.GetAtomicNum()) #don't exceed this - note using RDKit values
+        #set max valance to the smallest max allowed by openbabel or rdkit
+        #since we want the molecule to be valid for both (rdkit is usually lower)
+        maxb = openbabel.GetMaxBonds(a.GetAtomicNum())
+        maxb = min(maxb,pt.GetDefaultValence(a.GetAtomicNum())) 
         if 'Donor' in types[i]:
             maxb -= 1 #leave room for hydrogen
         atom_maxb[a.GetIdx()] = maxb
     
-    bonds = [b for b in openbabel.OBMolBondIter(mol)]
-    binfo = []
-    for bond in bonds:
-        bdist = bond.GetLength()
-        #compute how far away from optimal we are
-        a1 = bond.GetBeginAtom()
-        a2 = bond.GetEndAtom()
-        ideal = openbabel.GetCovalentRad(a1.GetAtomicNum()) + openbabel.GetCovalentRad(a2.GetAtomicNum()) 
-        stretch = bdist-ideal
-        binfo.append((stretch,bdist,bond))
-    binfo.sort(reverse=True, key=lambda t: t[:2]) #most stretched bonds first
+    def get_bond_info(biter):
+        '''Return bonds sorted by their distortion'''
+        bonds = [b for b in biter]
+        binfo = []
+        for bond in bonds:
+            bdist = bond.GetLength()
+            #compute how far away from optimal we are
+            a1 = bond.GetBeginAtom()
+            a2 = bond.GetEndAtom()
+            ideal = openbabel.GetCovalentRad(a1.GetAtomicNum()) + openbabel.GetCovalentRad(a2.GetAtomicNum()) 
+            stretch = bdist-ideal
+            binfo.append((stretch,bdist,bond))
+        binfo.sort(reverse=True, key=lambda t: t[:2]) #most stretched bonds first
+        return binfo
+        
+    #prioritize removing hypervalency causing bonds, do more valent 
+    #constrained atoms first since their bonds introduce the most problems
+    #with reachability (e.g. oxygen)
+    hypers = sorted([(atom_maxb[a.GetIdx()],a.GetExplicitValence() - atom_maxb[a.GetIdx()], a) for a in atoms],key=lambda aa: (aa[0],-aa[1]))
+    for mb,diff,a in hypers:
+        if a.GetExplicitValence() <= atom_maxb[a.GetIdx()]:
+            continue
+        binfo = get_bond_info(openbabel.OBAtomBondIter(a))            
+        for stretch,bdist,bond in binfo:
+            #can we remove this bond without disconnecting the molecule?
+            a1 = bond.GetBeginAtom()
+            a2 = bond.GetEndAtom()
+
+            #get right valence
+            if a1.GetExplicitValence() > atom_maxb[a1.GetIdx()] or \
+                a2.GetExplicitValence() > atom_maxb[a2.GetIdx()]:
+                #don't fragment the molecule
+                if not reachable(a1,a2):
+                    continue
+                mol.DeleteBond(bond)
+                if a.GetExplicitValence() <= atom_maxb[a.GetIdx()]:
+                    break #let nbr atoms choose what bonds to throw out
+                
     
+    binfo = get_bond_info(openbabel.OBMolBondIter(mol))
+    #now eliminate geometrically poor bonds
     for stretch,bdist,bond in binfo:
         #can we remove this bond without disconnecting the molecule?
         a1 = bond.GetBeginAtom()
         a2 = bond.GetEndAtom()
-        #don't fragment the molecule
-        if not reachable(a1,a2):
-            continue
 
         #as long as we aren't disconnecting, let's remove things
         #that are excessively far away (0.45 from ConnectTheDots)
         #get bonds to be less than max allowed
         #also remove tight angles, because that is what ConnectTheDots does
-        if stretch > 0.45 or  \
-            a1.GetExplicitValence() > atom_maxb[a1.GetIdx()] or \
-            a2.GetExplicitValence() > atom_maxb[a2.GetIdx()] or \
-            forms_small_angle(a1,a2) or forms_small_angle(a2,a1):
+        if stretch > 0.45 or forms_small_angle(a1,a2) or forms_small_angle(a2,a1):
+            #don't fragment the molecule
+            if not reachable(a1,a2):
+                continue
             mol.DeleteBond(bond)
-            continue                        
             
     mol.EndModify()
             
@@ -468,7 +492,7 @@ def make_obmol(struct,verbose=False):
                 print("Not Aromatic",ch.name,a.GetX(),a.GetY(),a.GetZ())
         
 
-    return mol,mismatches
+    return pybel.Molecule(mol),mismatches
     
 def calc_valence(rdatom):
     '''Can call GetExplicitValence before sanitize, but need to
@@ -478,8 +502,7 @@ def calc_valence(rdatom):
         cnt += bond.GetBondTypeAsDouble()
     return cnt
     
-def convert_ob_mol_to_rd_mol(ob_mol):
-  try:  
+def convert_ob_mol_to_rd_mol(ob_mol,struct):
     '''Convert OBMol to RDKit mol, fixing up issues'''
     ob_mol.DeleteHydrogens()
     n_atoms = ob_mol.NumAtoms()
@@ -559,6 +582,14 @@ def convert_ob_mol_to_rd_mol(ob_mol):
         Chem.SanitizeMol(rd_mol,Chem.SANITIZE_ALL^Chem.SANITIZE_KEKULIZE)
     except: # mtr22 - don't assume mols will pass this
         pass
+        # dkoes - but we want to make failures as rare as possible and should debug them        
+        m = pybel.Molecule(ob_mol)
+        i = np.random.randint(1000000)
+        outname = 'bad%d.sdf'%i
+        print("WRITING",outname)
+        m.write('sdf',outname,overwrite=True)
+        pickle.dump(struct,open('bad%d.pkl'%i,'wb'))
+        
 
     #but at some point stop trying to enforce our aromaticity -
     #openbabel and rdkit have different aromaticity models so they
@@ -573,9 +604,7 @@ def convert_ob_mol_to_rd_mol(ob_mol):
             bond.SetIsAromatic(True)
     
     return rd_mol
-  except:
-    pickle.dump(ob_mol,open('badstruct.pkl','wb'))
-    raise    
+        
     
 def make_rdmol(struct,verbose=False):
     '''Create RDKIT mol from MolStruct trying to respect types.'''

--- a/generate.py
+++ b/generate.py
@@ -475,7 +475,7 @@ class AtomFitter(object):
                 if struct_id in visited:
                     continue
 
-                print('expanding struct {} to {} next atoms'.format(struct_id, len(c_next)))
+                #print('expanding struct {} to {} next atoms'.format(struct_id, len(c_next)))
 
                 if self.multi_atom: # evaluate all next atoms simultaneously
 
@@ -700,12 +700,10 @@ class AtomFitter(object):
         visited_mols = [rd_mol]
 
         if self.dkoes_make_mol:
-
             pb_mol, misses = dkoes_fitting.make_obmol(struct, self.verbose)
             ob_mol = pb_mol.OBMol
             visited_mols.append(ob_mol_to_rd_mol(ob_mol))
-
-            rd_mol = dkoes_fitting.convert_ob_mol_to_rd_mol(ob_mol)
+            rd_mol = dkoes_fitting.convert_ob_mol_to_rd_mol(ob_mol,struct)
             visited_mols.append(rd_mol)
 
         elif self.mtr22_make_mol:
@@ -1226,7 +1224,7 @@ def catch_exc(func, exc=Exception, default=np.nan):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except exc as e:
+        except exc as e:            
             return default
     return wrapper
 


### PR DESCRIPTION
Prioritize removing hypervalent bonds over other undesirable bonds.  Use rdkit limit for valence even when making obmol.