### PR TITLE
Fix path to test files in test_atom_fitting.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Python
+__pycache__/

--- a/tests/test_atom_fitting.py
+++ b/tests/test_atom_fitting.py
@@ -13,13 +13,13 @@ from liGAN.metrics import compute_struct_rmsd
 
 
 test_sdf_files = [
-    'data/O_2_0_0.sdf',
-    'data/N_2_0_0.sdf',
-    'data/C_2_0_0.sdf',
-    'data/benzene.sdf',
-    'data/neopentane.sdf',
-    'data/sulfone.sdf',
-    'data/ATP.sdf',
+    'tests/input/O_2_0_0.sdf',
+    'tests/input/N_2_0_0.sdf',
+    'tests/input/C_2_0_0.sdf',
+    'tests/input/benzene.sdf',
+    'tests/input/neopentane.sdf',
+    'tests/input/sulfone.sdf',
+    'tests/input/ATP.sdf',
 ]
 
 


### PR DESCRIPTION
Test SDF files seem to have moved from `data/*.sdf` to `tests/input/*.sdf`. This PR fixes the path to such files so that
```
pytest tests/test_atom_fitting.py
```
can use such files.

---

Probably unrelated, but I still get some test failures locally:
```
============================================================= short test summary info =============================================================
FAILED tests/test_atom_fitting.py::TestAtomFitter::test_fit_struct[tests/input/sulfone.sdf-oadc-0.50] - AssertionError: different property count...
FAILED tests/test_atom_fitting.py::TestAtomFitter::test_fit_struct[tests/input/sulfone.sdf-on-1.50] - AssertionError: different num atoms (-1)
FAILED tests/test_atom_fitting.py::TestAtomFitter::test_fit_struct[tests/input/ATP.sdf-oadc-0.50] - AssertionError: different property counts (8.0)
FAILED tests/test_atom_fitting.py::TestAtomFitter::test_fit_struct[tests/input/ATP.sdf-oadc-1.50] - AssertionError: different property counts (1.0)
============================================== 4 failed, 573 passed, 66 warnings in 74.00s (0:01:14) =============================================
```