### PR TITLE
Enable wandb to be used for metric logging in pytorch implementation

### DIFF
--- a/liGAN/training.py
+++ b/liGAN/training.py
@@ -77,6 +77,7 @@ class GenerativeSolver(nn.Module):
         self,
         out_prefix,
         data_kws={},
+        wandb_kws: dict = {},
         gen_model_kws={},
         disc_model_kws={},
         prior_model_kws={},
@@ -88,8 +89,7 @@ class GenerativeSolver(nn.Module):
         bond_adding_kws={},
         device='cuda',
         debug=False,
-        sync_cuda=False,
-        use_wandb: bool = False
+        sync_cuda=False
     ):
         super().__init__()
         self.device = device
@@ -147,7 +147,8 @@ class GenerativeSolver(nn.Module):
         self.debug = debug
         self.sync_cuda = sync_cuda
 
-        self.use_wandb: bool = use_wandb
+
+        self.use_wandb: bool = self.wandb_kws['use_wandb']
         if self.use_wandb:
             try:
                 wandb
@@ -1023,10 +1024,10 @@ class GenerativeSolver(nn.Module):
             self.insert_metrics(idx, metrics)
 
             # log metrics to wandb
-            wandb_metrics = metrics.copy()
-            wandb_metrics.update(dict(zip(self.index_cols, idx)))
-            wandb.log(wandb_metrics)
-
+            if self.use_wandb:
+                wandb_metrics = metrics.copy()
+                wandb_metrics.update(dict(zip(self.index_cols, idx)))
+                wandb.log(wandb_metrics)
 
         idx = idx[:-1]
         metrics = self.metrics.loc[idx].mean()

--- a/liGAN/training.py
+++ b/liGAN/training.py
@@ -147,7 +147,7 @@ class GenerativeSolver(nn.Module):
         self.debug = debug
         self.sync_cuda = sync_cuda
 
-
+        self.wandb_kws = wandb_kws
         self.use_wandb: bool = self.wandb_kws['use_wandb']
         if self.use_wandb:
             try:

--- a/train.py
+++ b/train.py
@@ -22,6 +22,9 @@ def main(argv):
     with open(args.config_file) as f:
         config = yaml.safe_load(f)
 
+    if 'wandb' in config and 'use_wandb' not in config['wandb']:
+        raise Exception('use_wandb must be included in wandb configs')
+
     if 'wandb' in config and config['wandb']['use_wandb']:
         import wandb
         if 'init_kwargs' in config['wandb']:

--- a/train.py
+++ b/train.py
@@ -25,9 +25,9 @@ def main(argv):
     if 'wandb' in config and config['wandb']['use_wandb']:
         import wandb
         if 'init_kwargs' in config['wandb']:
-            wandb.init(**config['wandb']['init_kwargs'])
+            wandb.init(config=config, **config['wandb']['init_kwargs'])
         else:
-            wandb.init()
+            wandb.init(config=config)
         if 'out_prefix' not in config:
             try:
                 os.mkdir('wandb_output')

--- a/train.py
+++ b/train.py
@@ -25,9 +25,10 @@ def main(argv):
     if 'wandb' in config and config['wandb']['use_wandb']:
         import wandb
         if 'init_kwargs' in config['wandb']:
-            wandb.init(config=config, **config['wandb']['init_kwargs'])
+            wandb.init(settings=wandb.Settings(start_method="fork"),
+            config=config, **config['wandb']['init_kwargs'])
         else:
-            wandb.init(config=config)
+            wandb.init(settings=wandb.Settings(start_method="fork"), config=config)
         if 'out_prefix' not in config:
             try:
                 os.mkdir('wandb_output')

--- a/train.py
+++ b/train.py
@@ -55,6 +55,7 @@ def main(argv):
         device=device,
         debug=args.debug,
         sync_cuda=config.get('sync_cuda', False),
+        use_wandb=args.wandb
     )
 
     if config['continue']:

--- a/train.py
+++ b/train.py
@@ -10,7 +10,8 @@ def parse_args(argv):
     parser.add_argument('--debug', default=False, action='store_true')
     # TODO reimplement the following arguments
     parser.add_argument('--instance_noise', type=float, default=0.0, help='standard deviation of disc instance noise (default 0.0)')
-    parser.add_argument('--wandb', action='store_true', help='enable weights and biases')
+    # removing wandb option in place of putting wandb configs in the config file
+    # parser.add_argument('--wandb', action='store_true', help='enable weights and biases')
     parser.add_argument('--lr_policy', type=str, help='learning rate policy')
     return parser.parse_args(argv)
 
@@ -21,9 +22,12 @@ def main(argv):
     with open(args.config_file) as f:
         config = yaml.safe_load(f)
 
-    if args.wandb:
+    if 'wandb' in config and config['wandb']['use_wandb']:
         import wandb
-        wandb.init(project='gentrain', config=config)
+        if 'init_kwargs' in config['wandb']:
+            wandb.init(**config['wandb']['init_kwargs'])
+        else:
+            wandb.init()
         if 'out_prefix' not in config:
             try:
                 os.mkdir('wandb_output')
@@ -42,6 +46,7 @@ def main(argv):
     )
     solver = solver_type(
         data_kws=config['data'],
+        wandb_kws=config.get('wandb', {'use_wandb': False}),
         gen_model_kws=config['gen_model'],
         disc_model_kws=config.get('disc_model', {}),
         prior_model_kws=config.get('prior_model', {}),
@@ -54,8 +59,7 @@ def main(argv):
         out_prefix=config['out_prefix'],
         device=device,
         debug=args.debug,
-        sync_cuda=config.get('sync_cuda', False),
-        use_wandb=args.wandb
+        sync_cuda=config.get('sync_cuda', False)
     )
 
     if config['continue']:


### PR DESCRIPTION
This PR enables for wandb to be used with the pytorch implementation. It also allows for wandb to be configured via a "wandb" section in the config file.

This implementation only logs metrics to wandb. 