### PR TITLE
Expose GNINA executable

### DIFF
--- a/liGAN/molecules.py
+++ b/liGAN/molecules.py
@@ -18,8 +18,11 @@ from NP_Score import npscorer
 
 from .common import catch_exception
 
-GNINA_CMD = '/net/pulsar/home/koes/dkoes/local/bin/gnina'
-
+try:
+    GNINA_CMD = os.environ["GNINA_CMD"]
+except KeyError:
+    # Default path to gnina
+    GNINA_CMD = '/net/pulsar/home/koes/dkoes/local/bin/gnina'
 
 class Molecule(Chem.RWMol):
     '''


### PR DESCRIPTION
The path to the GNINA executable is currently hard-coded:
https://github.com/mattragoza/liGAN/blob/6842f35e39cac2cd9d8b308c978ec11d2f0f50e2/liGAN/molecules.py#L21

This PR allows to define the GNINA executable as an environment variable (and falls back to the original path by default).