### PR TITLE
Suppress ob warnings

### DIFF
--- a/train.py
+++ b/train.py
@@ -2,6 +2,7 @@
 import sys, os, argparse, yaml
 
 import liGAN
+from openbabel import openbabel as ob
 
 
 def parse_args(argv):
@@ -17,6 +18,7 @@ def parse_args(argv):
 
 
 def main(argv):
+    ob.obErrorLog.SetOutputLevel(0)
     args = parse_args(argv)
 
     with open(args.config_file) as f:


### PR DESCRIPTION
For some molecules, openbabel will generate a large number of error/warning messages. When using weights and biases, which captures/reports the stderr, these error messages can cause a deadlock that brings training to a halt. This deadlock is avoided by suppressing error and warning messages from openbabel, which is what this PR does.